### PR TITLE
Implement `ordered`, fix critical bug with `single`/`critical`

### DIFF
--- a/OpenMP.NET.Tests/ParallelTests.cs
+++ b/OpenMP.NET.Tests/ParallelTests.cs
@@ -8,7 +8,7 @@ namespace OpenMP.NET.Tests
 {
     public class ParallelTests
     {
-        /*[Fact]
+        [Fact]
         public void Parallel_performance_should_be_higher()
         {
             var elapsedParallel = Workload(true);
@@ -81,7 +81,7 @@ namespace OpenMP.NET.Tests
 
             OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                int id = OpenMP.Parallel.Critical(() => ++total);
+                int id = OpenMP.Parallel.Critical(5, () => ++total);
                 id.Should().Be(3);
             });
 
@@ -112,7 +112,7 @@ namespace OpenMP.NET.Tests
 
             OpenMP.Parallel.ParallelRegion(num_threads: threads, action: () =>
             {
-                OpenMP.Parallel.Single(() => ++total);
+                OpenMP.Parallel.Single(0, () => ++total);
             });
 
             total.Should().Be(1);
@@ -133,19 +133,18 @@ namespace OpenMP.NET.Tests
 
             total.Should().Be(threads);
             total2.Should().Be(-threads * 2);
-        }*/
+        }
 
         [Fact]
         public void Ordered_works()
         {
             uint threads = 8;
-            int[] incrementing = new int[threads];
+            int[] incrementing = new int[1024];
 
             OpenMP.Parallel.ParallelFor(0, 1024, schedule: OpenMP.Parallel.Schedule.Static,
                                         num_threads: threads, action: i =>
             {
-                Console.WriteLine("Thread {0} is working on {1}", OpenMP.Parallel.GetThreadNum(), i);
-                OpenMP.Parallel.Ordered(() => incrementing[i] = i);
+                OpenMP.Parallel.Ordered(0, () => incrementing[i] = i);
             });
 
             for (int i = 0; i < incrementing.Length; i++)
@@ -256,14 +255,14 @@ namespace OpenMP.NET.Tests
             {
                 OpenMP.Parallel.ParallelRegion(num_threads: 4, action: () =>
                 {
-                    int id1 = OpenMP.Parallel.Critical(() => ++x);
+                    int id1 = OpenMP.Parallel.Critical(0, () => ++x);
                     int id2 = -1;
 
                     OpenMP.Parallel.For(0, 100, schedule: OpenMP.Parallel.Schedule.Static, action: j =>
                     {
                         if (two_regions)
                         {
-                            id2 = OpenMP.Parallel.Critical(() => ++y);
+                            id2 = OpenMP.Parallel.Critical(1, () => ++y);
                         }
 
                         lock (mylock)

--- a/OpenMP.NET.Tests/ParallelTests.cs
+++ b/OpenMP.NET.Tests/ParallelTests.cs
@@ -8,7 +8,7 @@ namespace OpenMP.NET.Tests
 {
     public class ParallelTests
     {
-        [Fact]
+        /*[Fact]
         public void Parallel_performance_should_be_higher()
         {
             var elapsedParallel = Workload(true);
@@ -133,6 +133,25 @@ namespace OpenMP.NET.Tests
 
             total.Should().Be(threads);
             total2.Should().Be(-threads * 2);
+        }*/
+
+        [Fact]
+        public void Ordered_works()
+        {
+            uint threads = 8;
+            int[] incrementing = new int[threads];
+
+            OpenMP.Parallel.ParallelFor(0, 1024, schedule: OpenMP.Parallel.Schedule.Static,
+                                        num_threads: threads, action: i =>
+            {
+                Console.WriteLine("Thread {0} is working on {1}", OpenMP.Parallel.GetThreadNum(), i);
+                OpenMP.Parallel.Ordered(() => incrementing[i] = i);
+            });
+
+            for (int i = 0; i < incrementing.Length; i++)
+            {
+                incrementing[i].Should().Be(i);
+            }
         }
 
         private static long Workload(bool inParallel)

--- a/OpenMP.NET/Init.cs
+++ b/OpenMP.NET/Init.cs
@@ -10,11 +10,13 @@ namespace OpenMP
     {
         internal Thread thread;
         volatile internal int curr_iter;
+        internal int working_iter;
 
         internal Thr(Thread thread)
         {
             this.thread = thread;
             curr_iter = 0;
+            working_iter = 0;
         }
     }
 

--- a/OpenMP.NET/Iter.cs
+++ b/OpenMP.NET/Iter.cs
@@ -26,9 +26,10 @@ namespace OpenMP
             int end = (int)Math.Min(thr.curr_iter + chunk_size, Init.ws.end);
             Action<int> omp_fn = Init.ws.omp_fn;
 
-            for (int i = start; i < end; i++)
+            ref int i = ref thr.working_iter;
+
+            for (i = start; i < end; i++)
             {
-                //Console.WriteLine("Executing iteration {0} on thread {1}.", i, thread_id);
                 omp_fn(i);
             }
 
@@ -43,13 +44,13 @@ namespace OpenMP
 
             while (Init.ws.start < end)
             {
-                DynamicNext();
+                DynamicNext(thr);
             }
 
             Interlocked.Add(ref Init.ws.threads_complete, 1);
         }
 
-        private static void DynamicNext()
+        private static void DynamicNext(Thr thr)
         {
             int chunk_start;
 
@@ -62,9 +63,10 @@ namespace OpenMP
             int chunk_end = (int)Math.Min(chunk_start + Init.ws.chunk_size, Init.ws.end);
             Action<int> omp_fn = Init.ws.omp_fn;
 
-            for (int i = chunk_start; i < chunk_end; i++)
+            ref int i = ref thr.working_iter;
+
+            for (i = chunk_start; i < chunk_end; i++)
             {
-                //Console.WriteLine("Executing iteration {0} on thread {1}.", i, thread_id);
                 omp_fn(i);
             }
         }
@@ -77,13 +79,13 @@ namespace OpenMP
 
             while (Init.ws.start < end)
             {
-                GuidedNext();
+                GuidedNext(thr);
             }
 
             Interlocked.Add(ref Init.ws.threads_complete, 1);
         }
 
-        private static void GuidedNext()
+        private static void GuidedNext(Thr thr)
         {
             int chunk_start, chunk_size;
 
@@ -97,9 +99,10 @@ namespace OpenMP
             int chunk_end = (int)Math.Min(chunk_start + chunk_size, Init.ws.end);
             Action<int> omp_fn = Init.ws.omp_fn;
 
-            for (int i = chunk_start; i < chunk_end; i++)
+            ref int i = ref thr.working_iter;
+
+            for (i = chunk_start; i < chunk_end; i++)
             {
-                //Console.WriteLine("Executing iteration {0} on thread {1}.", i, thread_id);
                 omp_fn(i);
             }
         }


### PR DESCRIPTION
`single` and `critical` had an issue where certain lambdas would register different `GetHashCode()` return values, despite being the same lambda. This is due to how delegates are compiled in C#. The trigger was a sufficiently complex delegate that forced the compiler to generate a new class to contain the delegate. Then, when the class was instantiated multiple times, the delegates would have different hash codes. I have provided an emergency fix by requiring `ordered`/`critical`/`single` to take an `int id` parameter which we trust the user to be unique. This specifies the ID of the construct. I will document this in the README.