### PR TITLE
Improve CI/CD and building OpenMP.NET

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,4 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: .NET
+name: Test OpenMP.NET
 
 on:
   push:
@@ -20,13 +17,13 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore OpenMP.NET/
-    - name: Build
-      run: dotnet build --no-restore OpenMP.NET
-    - name: Restore dependencies
-      run: dotnet restore OpenMP.NET.Tests/
-    - name: Build
-      run: dotnet build --no-restore OpenMP.NET.Tests/
-    - name: Test
+    - name: Build main project
+      run: make build
+    - name: Build tests
+      run: make tests
+    - name: Build examples
+      run: make examples
+    - name: Build documentation
+      run: make docs
+    - name: Run tests
       run: dotnet test --no-build --verbosity normal OpenMP.NET.Tests/

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -25,5 +24,23 @@ jobs:
       run: make examples
     - name: Build documentation
       run: make docs
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
     - name: Run tests
       run: dotnet test --no-build --verbosity normal OpenMP.NET.Tests/
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Publish wiki
+      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      with:
+        path: "OpenMP.NET.Docs/html"
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -1,0 +1,18 @@
+name: Publish OpenMP.NET Wiki
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Publish wiki
+      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      with:
+        path: "OpenMP.NET.Docs/html"
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -5,6 +5,13 @@ on:
     branches: [ "main" ]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build Doxygen documentation
+      uses: mattnotmitt/doxygen-action@1.9.5
+
   publish:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
     - name: Build Doxygen documentation
       uses: mattnotmitt/doxygen-action@1.9.5
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
     - name: Publish wiki
       uses: SwiftDocOrg/github-wiki-publish-action@v1
       with:

--- a/.github/workflows/test_ompnet.yml
+++ b/.github/workflows/test_ompnet.yml
@@ -32,15 +32,3 @@ jobs:
     steps:
     - name: Run tests
       run: dotnet test --no-build --verbosity normal OpenMP.NET.Tests/
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-    - name: Publish wiki
-      uses: SwiftDocOrg/github-wiki-publish-action@v1
-      with:
-        path: "OpenMP.NET.Docs/html"
-      env:
-        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/test_ompnet.yml
+++ b/.github/workflows/test_ompnet.yml
@@ -22,8 +22,6 @@ jobs:
       run: make tests
     - name: Build examples
       run: make examples
-    - name: Build documentation
-      run: make docs
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_ompnet.yml
+++ b/.github/workflows/test_ompnet.yml
@@ -34,4 +34,4 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Run tests
-      run: dotnet test --no-build --verbosity normal OpenMP.NET.Tests/
+      run: dotnet test --verbosity normal OpenMP.NET.Tests/

--- a/.github/workflows/test_ompnet.yml
+++ b/.github/workflows/test_ompnet.yml
@@ -28,5 +28,10 @@ jobs:
     needs: build
 
     steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
     - name: Run tests
       run: dotnet test --no-build --verbosity normal OpenMP.NET.Tests/

--- a/Doxyfile
+++ b/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../OpenMP.NET.Docs
+OUTPUT_DIRECTORY       = OpenMP.NET.Docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -864,8 +864,8 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  += ../README.md
-INPUT                  += .
+INPUT                  = README.md
+INPUT                  += ./OpenMP.NET
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1063,7 +1063,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+DN=dotnet
+
+all: docs build tests examples
+
+examples: examples-cs examples-omp examples-seq
+
+examples-cs:
+	$(DN) build -c Release examples/CSParallel/ConjugateGradient
+	$(DN) build -c Release examples/CSParallel/HeatTransfer
+	$(DN) build -c Release examples/CSParallel/GEMM
+
+examples-omp:
+	$(DN) build -c Release examples/OpenMP.NET/ConjugateGradient
+	$(DN) build -c Release examples/OpenMP.NET/HeatTransfer
+	$(DN) build -c Release examples/OpenMP.NET/GEMM
+
+examples-seq:
+	$(DN) build -c Release examples/Serial/ConjugateGradient
+	$(DN) build -c Release examples/Serial/HeatTransfer
+	$(DN) build -c Release examples/Serial/GEMM
+
+tests:
+	$(DN) build -c Release OpenMP.NET.Tests
+
+test:
+	$(DN) test -c Release OpenMP.NET.Tests
+
+build:
+	$(DN) build -c Release OpenMP.NET
+
+docs:
+	doxygen
+
+clean:
+	rm -rf OpenMP.NET.Docs
+	rm -rf OpenMP.NET/bin OpenMP.NET/obj
+	rm -rf OpenMP.NET.Tests/bin OpenMP.NET.Tests/obj
+	rm -rf examples/CSParallel/ConjugateGradient/bin examples/CSParallel/ConjugateGradient/obj
+	rm -rf examples/CSParallel/HeatTransfer/bin examples/CSParallel/HeatTransfer/obj
+	rm -rf examples/CSParallel/GEMM/bin examples/CSParallel/GEMM/obj
+	rm -rf examples/OpenMP.NET/ConjugateGradient/bin examples/OpenMP.NET/ConjugateGradient/obj
+	rm -rf examples/OpenMP.NET/HeatTransfer/bin examples/OpenMP.NET/HeatTransfer/obj
+	rm -rf examples/OpenMP.NET/GEMM/bin examples/OpenMP.NET/GEMM/obj
+	rm -rf examples/Serial/ConjugateGradient/bin examples/Serial/ConjugateGradient/obj
+	rm -rf examples/Serial/HeatTransfer/bin examples/Serial/HeatTransfer/obj
+	rm -rf examples/Serial/GEMM/bin examples/Serial/GEMM/obj

--- a/README.md
+++ b/README.md
@@ -2,13 +2,46 @@
 A library for writing OpenMP-style parallel code in .NET.
 Inspired by the fork-join paradigm of OpenMP, and attempts to replicate the OpenMP programming style as faithfully as possible, though breaking spec at times.
 
+## Building OpenMP.NET
+OpenMP.NET can be built using the `make` command.
+To build the entire project, including all tests, examples, and documentation, run the following command:
+```sh
+make
+```
+This command will build the main library, all tests, all examples, and the documentation into their respective directories, but will not run any tests.
+
+To build only the main library, run the following command:
+```sh
+make build
+```
+
+To build only the tests, run the following command:
+```sh
+make tests
+```
+To run the tests, run the following command:
+```sh
+make test
+```
+
+To build only the examples, run the following command:
+```sh
+make examples
+```
+This will build all of the examples, including the native C# parallelized, the OpenMP.NET parallelized, and the sequential examples.
+You can also individually build each of these classes of examples by running one or all of the following commands:
+```sh
+make examples-cs
+make examples-omp
+make examples-seq
+```
+
 ## Documentation
 You can use [Doxygen](https://github.com/doxygen/doxygen) to build the documentation for this project.
-A Doxyfile is located under the `OpenMP.NET` directory.
-To build the documentation, run the following commands:
+A Doxyfile is located in the root of the project directory.
+To build the documentation, run the following command:
 ```sh
-cd OpenMP.NET
-doxygen Doxyfile
+make docs
 ```
 This will generate documentation in the root of the project under the `OpenMP.NET.Docs` directory in both LaTeX and HTML formats.
 


### PR DESCRIPTION
This PR improves CI/CD such that it publishes to the project wiki on a push to the main branch, and uploads auto-generated Doxygen documentation. Also adds a Makefile for easy building of the project.